### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-commits.yml
+++ b/.github/workflows/validate-commits.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Validate Commit Messages
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/phani-kb/dns-toolkit/security/code-scanning/1](https://github.com/phani-kb/dns-toolkit/security/code-scanning/1)

To fix the problem, the workflow must explicitly define permissions. Since the workflow only validates commit messages and does not modify repository contents, the permissions can be set to `contents: read` at the workflow level. This ensures the `GITHUB_TOKEN` has the least privilege required to complete the task.

Changes should be made at the root of the workflow file, adding a `permissions` block immediately after the `name` key to limit permissions globally for all jobs. No additional methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
