### PR TITLE
Potential fix for code scanning alert no. 3: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -848,6 +848,11 @@ func extractZipFile(logger *multilog.Logger, f *zip.File, destFolder string) err
 		return err
 	}
 
+	// Explicitly check for directory traversal elements in the file name
+	if strings.Contains(f.Name, "..") {
+		return fmt.Errorf("invalid file path in archive: %s", f.Name)
+	}
+
 	filePath := filepath.Join(destFolder, f.Name)
 
 	if !isWithinDirectory(destFolder, filePath) {


### PR DESCRIPTION
Potential fix for [https://github.com/phani-kb/dns-toolkit/security/code-scanning/3](https://github.com/phani-kb/dns-toolkit/security/code-scanning/3)

The issue can be resolved by adding a straightforward validation step for `f.Name` to ensure it does not contain directory traversal elements (`..`) before proceeding with any filesystem operations. This validation should complement the checks already performed by `validateArchiveFilePath` and `isWithinDirectory`.

The recommended fix involves:
1. Modifying the `extractZipFile` function to include an explicit check for "`..`" in the `f.Name` string using `strings.Contains`.
2. If `f.Name` contains "`..`", the function should return an error indicating an invalid file path.
3. This ensures that tainted or malicious input is caught early in the process.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
