### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -735,6 +735,10 @@ func extractTarGz(logger *multilog.Logger, archivePath, destFolder string) error
 		}
 
 		// Determine the correct path for extraction
+		// Ensure the file path does not contain directory traversal elements
+		if strings.Contains(head.Name, "..") {
+			return fmt.Errorf("invalid file path in archive: %s (contains '..')", head.Name)
+		}
 		if err := validateArchiveFilePath(head.Name); err != nil {
 			return err
 		}
@@ -774,6 +778,10 @@ func extractTarGz(logger *multilog.Logger, archivePath, destFolder string) error
 			// also create a copy in a subdirectory named after the archive base name
 			// This helps with archives that contain files directly at the root
 			if !strings.Contains(head.Name, "/") && !strings.Contains(head.Name, "\\") {
+				// Ensure the base name does not contain directory traversal elements
+				if strings.Contains(baseName, "..") {
+					return fmt.Errorf("invalid archive base name: %s (contains '..')", baseName)
+				}
 				if err := validateArchiveFilePath(baseName); err != nil {
 					return fmt.Errorf("invalid archive base name: %v", err)
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/phani-kb/dns-toolkit/security/code-scanning/2](https://github.com/phani-kb/dns-toolkit/security/code-scanning/2)

The best way to fix the problem is to ensure that all file paths extracted from the archive are thoroughly sanitized and verified before being used for file system operations. Specifically:
1. Reject any file paths containing directory traversal elements like "`..`".
2. Ensure that all constructed file paths remain within the intended destination directory (`destFolder`).
3. Apply these validations consistently before performing operations such as creating directories or files.

This can be achieved by enhancing the `validateArchiveFilePath` function (or adding a new path validation mechanism) to explicitly check for "`..`" and ensuring that its usage covers all relevant paths. Additionally, we should implement a stricter validation mechanism for `head.Name` to prevent directory traversal attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
